### PR TITLE
Set 'dist' to be included when releasing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "webpack-cli": "5.1.4",
     "webpack-dev-server": "5.0.2"
   },
-  "packageManager": "yarn@4.1.1"
+  "packageManager": "yarn@4.1.1",
+  "files": ["dist"]
 }


### PR DESCRIPTION
When need to list `dist` within `files` as it is not checked in and it'll only be generated when building/releasing the package.
Please lmk if you think we'll need to (or should) list anything else.