### PR TITLE
Fix hot reload in developer mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const { styles } = require("@ckeditor/ckeditor5-dev-utils");
 const CopyPlugin = require("copy-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 
-module.exports = {
+module.exports = (env, argv) => ({
   entry: "./src/index.js",
   output: {
     filename: "main.js",
@@ -109,14 +109,15 @@ module.exports = {
   optimization: {
     minimize: true,
     minimizer: [
-      new TerserPlugin({
-        extractComments: false,
-        terserOptions: {
-          format: {
-            comments: false,
+      argv.mode === "production" &&
+        new TerserPlugin({
+          extractComments: false,
+          terserOptions: {
+            format: {
+              comments: false,
+            },
           },
-        },
-      }),
+        }),
     ],
   },
-};
+});


### PR DESCRIPTION
`TerserPlugin` should only be applied in production so it does not throw during development.