### PR TITLE
Localize 'Upload image from computer'

### DIFF
--- a/src/localization.js
+++ b/src/localization.js
@@ -6,6 +6,7 @@ export const ckeditorTranslationsKeyMap = {
   Link: "help-center-wysiwyg.link",
   Code: "help-center-wysiwyg.code",
   "Insert image": "help-center-wysiwyg.insert-image",
+  "Upload image from computer": "help-center-wysiwyg.insert-image",
   "Block quote": "help-center-wysiwyg.block-quote",
   "Insert code block": "help-center-wysiwyg.insert-code-block",
   "Bulleted List": "help-center-wysiwyg.bulleted-list",


### PR DESCRIPTION
We updated CKEditor when we extracted it and once of the changes was in the "Insert image" button, which was replaced by the "file dialog". We updated the svg icon but forgot to adjust the localized string.