### PR TITLE
Bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zendesk/help-center-wysiwyg",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Wysiwyg editor used in Zendesk Help Center",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "dist/main.js",


### PR DESCRIPTION
We have not yet automated the release process for the package so we are still doing it manually.
There was mistake while "offline" publishing the `v0.0.4` build so I'm bumping the package so we can redo it and get it fixed.