### PR TITLE
Add id to changeset action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create Changeset PR
     runs-on: ubuntu-latest
     outputs:
-      changeset: ${{ steps.changeset.outputs.hasChangesets }}
+      changeset: ${{ steps.changesets.outputs.hasChangesets }}
 
     steps:
       - name: Checkout Repo
@@ -27,6 +27,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Output is currently null due to lack of id, causing the github action for npm-publish not to work and release the package. Adding the id should ensure the parameter for changesets gets correctly read and triggers the release