### PR TITLE
Fix z-index on link pop-up

### DIFF
--- a/.changeset/pink-pumpkins-tell.md
+++ b/.changeset/pink-pumpkins-tell.md
@@ -1,0 +1,5 @@
+---
+"@zendesk/help-center-wysiwyg": patch
+---
+
+Fix z-index on link popup

--- a/src/styles.css
+++ b/src/styles.css
@@ -82,6 +82,11 @@
   overflow: auto;
   white-space: pre;
 }
+
+.ck.ck-balloon-panel {
+  z-index: var(--ck-z-modal);
+}
+
 /*
   Prevent issue where some Zendesk Garden icons are completely filled with currentColor,
   making the icon itself invisible.


### PR DESCRIPTION
#### Description

This PR increases the z-index of the CKEditor link popup. This is necessary in order to be able to display the CKEditor link editor pop-up on top of . 


#### References

- https://zendesk.atlassian.net/browse/ULTRA-1145

#### Screenshots


After:
<img width="898" alt="image" src="https://github.com/user-attachments/assets/efae93fa-3f54-49a0-9b1e-b5fbe3cc8741">

#### Risks

<!--
Please apply exactly one of the risk labels:

- risk:none (only appropriate for PRs which don't affect what gets deployed, e.g. the README)
- risk:low
- risk:medium
- risk:high

-->

risk:low
