### PR TITLE
fix: include ckeditor license keys when releasing new package versions

### DIFF
--- a/.changeset/little-donuts-yawn.md
+++ b/.changeset/little-donuts-yawn.md
@@ -1,0 +1,5 @@
+---
+"@zendesk/help-center-wysiwyg": patch
+---
+
+Include CKEditor licenses in publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+env:
+  CKEDITOR_LICENSE_KEY_PRODUCTION: ${{ secrets.CKEDITOR_LICENSE_KEY_PRODUCTION}}
+  CKEDITOR_LICENSE_KEY_DEVELOPMENT: ${{ secrets.CKEDITOR_LICENSE_KEY_DEVELOPMENT}}
+
 jobs:
   release: # action to create changesets
     name: Create Changeset PR


### PR DESCRIPTION
Second attempt at #28

The difference is that we're including those secrets as env variables for both jobs globally within the `release` workflow.