### PR TITLE
fix: inline build and release pipeline

### DIFF
--- a/.changeset/heavy-numbers-cross.md
+++ b/.changeset/heavy-numbers-cross.md
@@ -1,0 +1,9 @@
+---
+"@zendesk/help-center-wysiwyg": patch
+---
+
+Inline the build and release part of the workflow.
+
+This fixes the issue with the CKEditor license keys not being propagated to the reusable build & publish workflow due to [Github limitations](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#limitations).
+
+> Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. For more information, see "Store information in variables" and "Accessing contextual information about workflow runs."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
   CKEDITOR_LICENSE_KEY_PRODUCTION: ${{ secrets.CKEDITOR_LICENSE_KEY_PRODUCTION}}
   CKEDITOR_LICENSE_KEY_DEVELOPMENT: ${{ secrets.CKEDITOR_LICENSE_KEY_DEVELOPMENT}}
+  NODE_VERSION: "20"
 
 jobs:
   release: # action to create changesets
@@ -37,11 +38,65 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   npm-publish:
-    uses: zendesk/gw/.github/workflows/npm-publication.yml@main
+    name: Build + Publish
+    runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.changeset == 'false' }}
-    with:
-      node_version: "20"
-    secrets:
-      NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-      NPM_TOTP_DEVICE: ${{secrets.NPM_TOTP_DEVICE}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      # Use yarn2
+      - name: Install Yarn
+        run: npm install -g yarn
+      - name: Set Yarn Version
+        run: yarn set version berry
+
+      - id: find-yarn-cache-folder
+        name: Find Yarn's cache folder
+        run: echo "YARN_CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_ENV
+
+      - name: Cache Yarn's cache folder
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.YARN_CACHE_FOLDER }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.NODE_VERSION }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.NODE_VERSION }}-
+            yarn-cache-folder-os-${{ runner.os }}-
+
+      - name: Install oauth
+        run: |
+          sudo apt-get install --fix-broken --yes oathtool
+
+      - name: Setup yarn
+        run: |
+          yarn config set npmPublishAccess public
+          yarn config set npmAlwaysAuth true
+          yarn config set npmRegistryServer https://registry.npmjs.org
+          yarn config set npmAuthToken $NPM_TOKEN
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Git config user
+        run: |
+          git config user.name zendesk-ops-ci
+          git config user.email zendesk-ops-ci@users.noreply.github.com
+
+      - name: Build and release
+        run: |
+          yarn install --immutable
+          yarn build
+          totp=$(oathtool --base32 --totp "${NPM_TOTP_DEVICE}")
+          yarn npm publish --otp $totp
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOTP_DEVICE: ${{ secrets.NPM_TOTP_DEVICE }}
+
+      - name: Clear the .yarnrc.yml file
+        if: always()
+        run: rm -f .yarnrc.yml


### PR DESCRIPTION
This fixes the issue with the CKEditor license keys not being propagated to the reusable build & publish workflow due to [Github limitations](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#limitations).

> Any environment variables set in an env context defined at the workflow level in the caller workflow are not propagated to the called workflow. For more information, see "Store information in variables" and "Accessing contextual information about workflow runs."