### PR TITLE
Add missing  configuration to the npm-publish workflow

### DIFF
--- a/.changeset/real-eagles-hang.md
+++ b/.changeset/real-eagles-hang.md
@@ -1,0 +1,5 @@
+---
+"@zendesk/help-center-wysiwyg": patch
+---
+
+Add missing `environment` configuration to the npm-publish workflow

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.changeset == 'false' }}
+    environment: npm-publish
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fix failing release workflow: https://github.com/zendesk/help-center-wysiwyg/actions/runs/11664535830/job/32475279737

<img width="624" alt="Screenshot 2024-11-04 at 13 58 51" src="https://github.com/user-attachments/assets/8c770ef5-b885-49e5-84d6-6a53fad585d9">

Apparently, it needs to be run in the `npm-publish` environment (the one containing the `NPM_TOKEN`, etc. secrets)