### PR TITLE
Updating MentionsDataProcessor to ensure data-user-name is set

### DIFF
--- a/.changeset/violet-trains-talk.md
+++ b/.changeset/violet-trains-talk.md
@@ -1,0 +1,5 @@
+---
+"@zendesk/help-center-wysiwyg": patch
+---
+
+Updating MentionsDataProcessor to set data-user-name to the attribute value of data-user-name we get from the span element to ensure the attribute value of data-user-name is defined on x-zendesk-user

--- a/src/plugins/CommunityMentionsPlugin/MentionsDataProcessor.js
+++ b/src/plugins/CommunityMentionsPlugin/MentionsDataProcessor.js
@@ -21,7 +21,7 @@ class MentionsDataProcessor {
           child._attrs = new Map();
           child._attrs.set(
             "data-user-name",
-            child.getAttribute("data-mention"),
+            child.getAttribute("data-user-name"),
           );
         } else if (child.getChildren) {
           findAndConvertMentionElements(child.getChildren());


### PR DESCRIPTION
Description:
Updating MentionsDataProcessor to set data-user-name to the attribute value of data-user-name we get from the span element to ensure the attribute value of data-user-name is defined on x-zendesk-user

Issue:
Currently when we try to send mentions data from the help-center-wysiwyg, the value or data-user-name is sent as, and returns as, undefined. We would expect this value to be set so that we can properly display the user's name in the mentions link to their profile when displaying something like article comment data.